### PR TITLE
Prototype for Tool Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,15 @@ Here are two ways you might configure the server in your `mcp.json`:
 ```json
 {
   "mcpServers": {
-    "github-mc-local-with-includes": {
-      "command": "./github-mcp-server",
+    "github-with-include-tools": {
+      "command": "docker",
       "args": [
-        "stdio",
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server",
         "--include-tools",
         "update_issue,create_issue"
       ],
@@ -132,10 +137,15 @@ Here are two ways you might configure the server in your `mcp.json`:
 ```json
 {
   "mcpServers": {
-    "github-mc-local-with-excludes": {
-      "command": "./github-mcp-server",
+    "github-with-include-tools": {
+      "command": "docker",
       "args": [
-        "stdio",
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server",
         "--exclude-tools",
         "get_file_contents,get_issue,get_issue_comments,get_me,get_pull_request,get_pull_request_comments,get_pull_request_files,get_pull_request_reviews,get_pull_request_status,list_code_scanning_alerts,list_commits,list_issues,list_pull_requests"
       ],

--- a/README.md
+++ b/README.md
@@ -95,6 +95,60 @@ If you don't have Docker, you can use `go` to build the binary in the
 command with the `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable set to
 your token.
 
+## Filtering Tools
+
+By default, the GitHub MCP Server exposes all available tools to the connected agent.
+You can customize which tools are available using the `--include-tools` and `--exclude-tools` command-line arguments.
+
+- `--include-tools`: Specifies a comma-separated list of tool names to include. Only these tools will be available. All other tools will be excluded.
+- `--exclude-tools`: Specifies a comma-separated list of tool names to exclude. All other tools will be available.
+
+These flags are mutually exclusive; you cannot use both at the same time.
+
+**Examples:**
+
+Here are two ways you might configure the server in your `mcp.json`:
+
+1. Include only specific tools (allowlist):
+```json
+{
+  "mcpServers": {
+    "github-mc-local-with-includes": {
+      "command": "./github-mcp-server",
+      "args": [
+        "stdio",
+        "--include-tools",
+        "update_issue,create_issue"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+2. Exclude specific tools (denylist):
+```json
+{
+  "mcpServers": {
+    "github-mc-local-with-excludes": {
+      "command": "./github-mcp-server",
+      "args": [
+        "stdio",
+        "--exclude-tools",
+        "get_file_contents,get_issue,get_issue_comments,get_me,get_pull_request,get_pull_request_comments,get_pull_request_files,get_pull_request_reviews,get_pull_request_status,list_code_scanning_alerts,list_commits,list_issues,list_pull_requests"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+Using these configuration options allows you to precisely control the capabilities granted to the AI agent connecting to the server, enhancing security and alignment with intended use cases.
+
 ## GitHub Enterprise Server
 
 The flag `--gh-host` and the environment variable `GH_HOST` can be used to set


### PR DESCRIPTION
# RFC - Prototype for MCP Tool Filtering
The problem outlined below is not unique to the GitHub MCP Server; but this server has a _lot_ of tools that are well understood by the community (and there's many more to implement!) so this felt like an ideal place for prototyping.

# Problem
MCP Servers conventionally expose _all_ tools they are capable of; which clients discover via [tools/list](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/#listing-tools). There are a number of problems with this:

* A user may wish to prevent their agents from using specific tools, while making use of other parts of the MCP Server.
  * Example: Some tools may be considered high risk
  * Example: Some tools may be capable of returning data which is not allowed to be exposed to LLMs
* Some clients have limitations on the number of MCP Servers and Tools they can interact with
  * Example: Cursor limits users to interacting with the first 40 tools discovered across servers
* Exposing unnecessary tools to agents is a waste of tokens
* Exposing undesired tools to agents pollutes context and confuses agents by giving a false sense of agency
* Some tools may not be available to the user because the credentials they associated with the server lack permission for the backing APIs 

Additionally, there are use cases in which a user may wish to have multiple instances of the same MCP Server, with differing configurations and tools available.
* Example:
  * Instance A of Github MCP, using an access token for Organization A, only accessing tools to read Pull Requests
  * Instance B of Github MCP, using an access token for Organization B, only accessing Issues and Users

# Proposal
Standardize `--include-tools` and `--exclude-tools` arguments when invoking `stdio` transport CLI tools.
* `--include-tools` applies an allowlist approach; only exposing the tools specified by the user
* `--exclude-tools` applies a denylist approach; exposing all tools except those specified by the user

By providing these as arguments to the process itself, we ensure the server itself _does not register_ these tools.
* This prevents them from being exposed to `tools/list`
* This prevents agents from calling them
* This ensures agents don't waste context tokens to know about tools they can't use

# Example Usage

In this branch, I have hacked filtering into the GitHub MCP Server. In Cursor's MCP configuration, I specify two instances of this server, with different tools available:

```json
  "mcpServers": {
    "github-mc-local-with-includes": {
      "command": "./github-mcp-server",
      "args": [
        "stdio",
        "--include-tools",
        "update_issue,create_issue"
      ],
      "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN": "OH_HI_THERE"
      }
    },
    "github-mc-local-with-excludes": {
      "command": "./github-mcp-server",
      "args": [
        "stdio",
        "--exclude-tools",
        "get_file_contents,get_issue,get_issue_comments,get_me,get_pull_request,get_pull_request_comments,get_pull_request_files,get_pull_request_reviews,get_pull_request_status,list_code_scanning_alerts,list_commits,list_issues,list_pull_requests"
      ],
      "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN": "LOL_NO_THANKS"
      }
    }
  }
```

Thus Cursor shows the filtered tools which are available:

<img width="964" alt="image" src="https://github.com/user-attachments/assets/45ea40da-be2f-47c1-b061-902cc3442ad1" />


### Pros
* Works with docker-based local MCP Servers
* Works with local binaries
* Works with NPM, NPX, etc. based local  MCP servers
* Allows users to store, share, and version control tool filters in the same place they store their server configurations (eg. `mcp.json`)
* Filters entirely upstream of agents and human-in-the-loop tool approvals
* Filtering at this level allows for server-specific groups of filters as well (eg. `--read-only` or `--exclude-super-admin-tools`)
* This would also allow servers to make dynamic decisions about tools to expose.
  * Example: On server process initialization, make an API call to inspect permissions associated with the client's credentials. Only expose tools which they have permission to use.

### Cons
* SSE Transport.... 🤔 

# Alternatives
* Do nothing - Leave this as an entirely client-side concern (Claude, Cursor, etc improve their UX around which tools should be available)